### PR TITLE
Add filters for extension

### DIFF
--- a/library/admin/render.php
+++ b/library/admin/render.php
@@ -585,7 +585,7 @@ class render {
     jQuery(document).ready(function($) {
 
         // build super multiselect ##
-        jQuery('#usermeta, #bp_fields, #bp_fields_update_time').multiSelect();
+        jQuery('select[multiple]').multiSelect();
 
         // Select any fields from saved settings ##
         jQuery('#usermeta').multiSelect('select',([ <?php echo implode( ',', array_map( function( $field ){ return "'".\esc_attr( $field )."'"; }, $_usermeta_saved_fields ) );; // escaped ?>]));

--- a/library/api/admin.php
+++ b/library/api/admin.php
@@ -48,7 +48,7 @@ class admin {
         }
 
         // is this toggleable ? ##
-        $toggleable = false === $array['title'] ? 'standard' : 'toggleable' ;
+        $toggleable = false === $array['toggleable'] ? 'standard' : 'toggleable' ;
 
         // keep labels formatted nicely ##
         $array['label'] = \sanitize_key( $array['label'] );
@@ -155,14 +155,18 @@ class admin {
         }
 
         // is this a multiselect ? ##
-        $multiselect = isset( $array['multiselect'] ) ? ' multiple="multiple"' : '' ;
+        $multiselect = ! empty( $array['multiselect'] ) ? ' multiple="multiple"' : '' ;
+        // If this is a multiselect, the name must reflect that.
+        $name_append =  ( $multiselect ) ? '[]' : '';
 
 ?>
-        <select <?php \esc_attr_e( $multiselect ); ?> name="<?php \esc_attr_e( $array['label'] ); ?>" id="q_eud_<?php \esc_attr_e( $array['label'] ); ?>">
+        <select <?php echo( $multiselect ); ?> name="<?php echo \esc_attr( $array['label'] ) . $name_append; ?>" id="q_eud_<?php \esc_attr_e( $array['label'] ); ?>">
 		<?php
 
             // label ##
-            echo '<option value="">'.\esc_attr( $array['label_select'] ).'</option>';
+            if ( ! empty( $array['label_select'] ) ) {
+                echo '<option value="">'.\esc_attr( $array['label_select'] ).'</option>';
+            }
 
             // loop over all options  ##
             foreach ( $array['options'] as $item ) {

--- a/library/core/export.php
+++ b/library/core/export.php
@@ -192,6 +192,9 @@ class export {
             ,	$usermeta_fields // wp_user_meta fields ##
         );
 
+        // Filter available fields.
+        $fields = \apply_filters( 'q/eud/export/fields', $fields );
+
         // test field array ##
         #h::log( $fields );
 
@@ -345,6 +348,9 @@ class export {
 
                     }
 
+                    // Allow plugins to supply values.
+                    $value = \apply_filters( 'q/eud/export/field_value_before_formatting', $value, $field, $user );
+
                 }
 
 				// ---------- cleanup and format the value, before exporting ##
@@ -363,7 +369,7 @@ class export {
 
 				}
 
-				// apply generic filter to value ##
+				// apply generic filter to format value ##
 				if( has_filter( 'q/eud/export/value' ) ){
 
 					$value = \apply_filters( 'q/eud/export/value', $value );


### PR DESCRIPTION
Hi Q Studio, Thanks for the useful plugin. I wanted to add back in support for exporting BuddyPress profile fields, so I wrote a small extension to your plugin. I ended up needing to add a couple of filter points and also making a few changes to the plugin's admin field API, which just needed a few tweaks to make it work to add a field.

You can see my extension here to see how I've hooked into your plugin: 
https://github.com/dcavins/export-user-data-add-buddypress-fields

Thanks!